### PR TITLE
Change image names to support docker hub repos

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
-TAG=local
+TAG=latest
 domain=scifi.farm
 stack_name=technocore
-image_provider=technocore
+image_provider=scififarms
 
 docs_live_mount="./docs:/src"
 home_assistant_live_mount="./home-assistant/config/:/config"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         mode: global
         restart_policy:
           condition: any
-    image: ${image_provider}/docs:${TAG}
+    image: ${image_provider}/technocore-docs:${TAG}
     ports:
       - "4000:4000"
       - 35729:35729
@@ -28,7 +28,7 @@ services:
       mode: global
       restart_policy:
         condition: any
-    image: ${image_provider}/home-assistant:${TAG}
+    image: ${image_provider}/technocore-home-assistant:${TAG}
     networks:
       web:
         # This was nessesary in order to get Node-RED to connect with Home Assistant.
@@ -61,7 +61,7 @@ services:
       mode: global
       restart_policy:
         condition: any
-    image: ${image_provider}/home-assistant-db:${TAG}
+    image: ${image_provider}/technocore-home-assistant-db:${TAG}
     networks:
       - web
     secrets:
@@ -86,7 +86,7 @@ services:
       mode: global
       restart_policy:
         condition: any
-    image: ${image_provider}/vernemq:${TAG}
+    image: ${image_provider}/technocore-vernemq:${TAG}
     networks:
       web:
         aliases:
@@ -132,7 +132,7 @@ services:
       mode: global
       restart_policy:
         condition: any
-    image: ${image_provider}/node-red:${TAG}
+    image: ${image_provider}/technocore-node-red:${TAG}
     networks:
       - web
     ports:
@@ -163,9 +163,7 @@ services:
         mode: global
         restart_policy:
           condition: any
-    devices:
-      - "/dev/ttyUSB0:/dev/ttyUSB0"
-    image: docker
+    image: ${image_provider}/technocore-platformio-wrapper:${TAG}
     networks:
       - web
     secrets:
@@ -188,7 +186,7 @@ services:
       mode: global
       restart_policy:
         condition: any
-    image: ${image_provider}/portainer:${TAG}
+    image: ${image_provider}/technocore-portainer:${TAG}
     networks:
       - web
     ports:
@@ -222,7 +220,7 @@ services:
       - VAULT_CACERT=/run/secrets/ca
       # This has been disabled because I don't think they are needed... But not sure enough to remove yet.
       #- VAULT_CA=true
-    image: ${image_provider}/vault:${TAG}
+    image: ${image_provider}/technocore-vault:${TAG}
     networks:
       web:
         aliases:

--- a/utilities/build.sh
+++ b/utilities/build.sh
@@ -2,11 +2,11 @@
 technocore_folder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${technocore_folder}/../.env 
 
-docker build ./docs/ -t ${image_provider}/docs:$TAG
-docker build ./home-assistant/ -t ${image_provider}/home-assistant:$TAG
-docker build ./home-assistant-db/ -t ${image_provider}/home-assistant-db:$TAG
-docker build ./node-red/ -t ${image_provider}/node-red:$TAG
-docker build ./platformio/ -t ${image_provider}/platformio:$TAG
-docker build ./vault/ -t ${image_provider}/vault:$TAG
-docker build ./vernemq/ -t ${image_provider}/vernemq:$TAG
-docker build ./portainer/ -t ${image_provider}/portainer:$TAG
+docker build ./docs/ -t ${image_provider}/technocore-docs:$TAG
+docker build ./home-assistant/ -t ${image_provider}/technocore-home-assistant:$TAG
+docker build ./home-assistant-db/ -t ${image_provider}/technocore-home-assistant-db:$TAG
+docker build ./node-red/ -t ${image_provider}/technocore-node-red:$TAG
+docker build ./platformio/ -t ${image_provider}/technocore-platformio:$TAG
+docker build ./vault/ -t ${image_provider}/technocore-vault:$TAG
+docker build ./vernemq/ -t ${image_provider}/technocore-vernemq:$TAG
+docker build ./portainer/ -t ${image_provider}/technocore-portainer:$TAG


### PR DESCRIPTION
I couldn't get the technocore organization from Docker Hub, so I used SciFiFarms instead. Then I prepended TechnoCore- to the image names. 